### PR TITLE
Fix player SetPos in Teleport type PLAYER_INFO (Opcode 81) Handling

### DIFF
--- a/src/com/jagex/runescape/Client.java
+++ b/src/com/jagex/runescape/Client.java
@@ -10050,7 +10050,7 @@ public final class Client extends RSApplet {
             }
             final int x = stream.readBits(7);
             final int y = stream.readBits(7);
-            localPlayer.setPos(y, x, clearWaypointQueue == 1);
+            localPlayer.setPos(x, y, clearWaypointQueue == 1);
         }
     }
 

--- a/src/com/jagex/runescape/Client.java
+++ b/src/com/jagex/runescape/Client.java
@@ -10048,8 +10048,9 @@ public final class Client extends RSApplet {
             if (updateRequired == 1) {
                 this.playersObserved[this.playersObservedCount++] = this.LOCAL_PLAYER_ID;
             }
-            final int x = stream.readBits(7);
+
             final int y = stream.readBits(7);
+            final int x = stream.readBits(7);
             localPlayer.setPos(x, y, clearWaypointQueue == 1);
         }
     }


### PR DESCRIPTION
Don't know how this wasn't noticed but found it when trying to backport the client to support 245 protocol on LostCity.